### PR TITLE
Windows build

### DIFF
--- a/opencj_discord.py
+++ b/opencj_discord.py
@@ -4,8 +4,9 @@ import asyncio
 import discord
 from util import sanitize
 from opencj_events import PlayerJoinedEvent, PlayerLeftEvent, PlayerMessageEvent, MapStartedEvent, PlayerCountChangedEvent, RunFinishedEvent
-from syslog import syslog
+import logging
 
+logger = logging.getLogger(__name__)
 
 class OpenCJDiscord(discord.Client):
     """
@@ -36,7 +37,7 @@ Class for Discord integration that will use and be used by the game server liste
         """
 
         if not self.is_ready:
-            syslog('Received event but not ready yet')
+            logger.info('Received event but not ready yet')
             return
 
         channel = self.get_channel(self.channel_id) # server-chat
@@ -63,7 +64,7 @@ Class for Discord integration that will use and be used by the game server liste
             status = f'{self.map_name} ({self.player_count})' if self.map_name else f'unknown ({self.player_count})'
             await self.change_presence(activity=discord.Game(name=status))
         else:
-            syslog(f'Unhandled event: {event}')
+            logger.info(f'Unhandled event: {event}')
 
 
     async def on_ready(self):
@@ -71,7 +72,7 @@ Class for Discord integration that will use and be used by the game server liste
     Gets called when the Discord bot is ready to roll
         """
         self.is_ready = True
-        syslog(f'Logged in as {self.user}')
+        logger.info(f'Logged in as {self.user}')
 
 
     async def on_message(self, message):
@@ -89,7 +90,7 @@ Class for Discord integration that will use and be used by the game server liste
                 if message.channel.id == self.channel_id:
                     # Check if a handle to the game server listener is available yet
                     if not self.gameserver:
-                        syslog('Received a message but game server listener isn\'t ready yet')
+                        logger.info('Received a message but game server listener isn\'t ready yet')
                         return
 
                     # Apply some basic restrictions

--- a/opencj_events.py
+++ b/opencj_events.py
@@ -3,7 +3,9 @@
 from enum import Enum
 from util import get_clean_message, get_clean_name, sanitize
 import sys
-from syslog import syslog
+import logging
+
+logger = logging.getLogger(__name__)
 
 class GameEvent():
     # These event numbers are hardcoded in opencj_discord.cpp and discord.gsc, do not change (only append)
@@ -29,7 +31,7 @@ class GameEvent():
                     if inst.create(args):
                         return inst
             except Exception as e:
-                syslog(f'Failed to create event for: {e}')
+                logger.info(f'Failed to create event for: {e}')
                 pass # Doesn't exist or failed to create
         return None
 

--- a/opencj_listener.py
+++ b/opencj_listener.py
@@ -2,12 +2,12 @@
 # It receives events from Discord module and forwards them to the game server
 # It receives events from the game server and forwards them to the Discord module
 
-from syslog import syslog
+import logging
 import asyncio
 import socket
-import os
 from opencj_events import GameEvent
 
+logger = logging.getLogger(__name__)
 
 class OpenCJListener():
     """
@@ -15,8 +15,7 @@ Interface between Discord and the game server
     """
     server = None # Listener socket
     client = None # Game server client that is connected
-    socket_prefix = '/tmp/opencj_events_' # Prefix of the socket path
-    socket_path = None # Path to the socket that will be used for listening
+    port = None # socket's TCP port
     dc = None # Discord integration module instance
 
     @staticmethod
@@ -36,8 +35,8 @@ Interface between Discord and the game server
 
 
     def __init__(self, discord_module, game_name):
-        self.socket_path = self.socket_prefix + game_name
         self.dc = discord_module
+        self.port = 28961
 
 
     async def handle_client(self, client):
@@ -47,14 +46,14 @@ Interface between Discord and the game server
         """
         # New client connected, closing previous since only one game server is expected
         if self.client is not None:
-            syslog('Unexpected game server client connected, dropping previous')
+            logger.info('Unexpected game server client connected, dropping previous')
             self.client.shutdown(socket.SHUT_RDWR)
             self.client.close()
 
         self.client = client
 
         # Process incoming data from client
-        syslog('Now handling new game server client')
+        logger.info('Now handling new game server client')
         loop = asyncio.get_event_loop()
         event = None # Events and their arguments are separated by space
         data = None
@@ -88,7 +87,7 @@ Interface between Discord and the game server
                     loop.create_task(self.dc.on_game_event(event))
                 else:
                     # Shouldn't always keep this on, but currently for debugging it's useful
-                    syslog(f'Flushing: {line}')
+                    logger.info(f'Flushing: {line}')
 
 
     async def on_discord_message(self, name, msg):
@@ -96,35 +95,29 @@ Interface between Discord and the game server
             data = f'^8[^7Discord^8]^7 {name}: {msg}'
             await asyncio.get_event_loop().sock_sendall(self.client, data.encode('ascii', 'ignore'))
         else:
-            syslog('Can\'t handle Discord event yet, no game server is listening')
+            logger.info('Can\'t handle Discord event yet, no game server is listening')
 
 
     async def start(self):
         """
-    This sets up the server Unix domain socket and listens to it for clients.
+    This sets up a TCP localhost socket and listens to it for clients.
     A client can be the Discord integration script or the game server.
         """
-        if not self.socket_path:
-            raise Exception('Running game server listener before setting socket path')
+        if not self.port:
+            raise Exception('Running game server listener before setting port')
 
-        syslog('Running game server listener')
-        # May already be open, in which case try to unlink it
-        try:
-            os.unlink(self.socket_path)
-        except OSError:
-            if os.path.exists(self.socket_path):
-                raise Exception('Socket already in use, but could not unlink..')
+        logger.info('Running game server listener')
 
-        # Set up the socket as non-blocking and start listening
-        self.server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # Set up the TCP socket as non-blocking and start listening
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.server.bind(self.socket_path)
+        self.server.bind(('127.0.0.1', self.port))
         self.server.listen(1)
         self.server.setblocking(False)
 
-        syslog('Server is listening for connections')
+        logger.info('Server is listening for connections')
         loop = asyncio.get_event_loop()
         while True:
             client, _ = await loop.sock_accept(self.server)
-            syslog(f'New client connected')
+            logger.info(f'New client connected')
             loop.create_task(self.handle_client(client))

--- a/start.py
+++ b/start.py
@@ -4,7 +4,9 @@ import discord
 from opencj_listener import OpenCJListener
 from opencj_discord import OpenCJDiscord, start_bot
 import sys
+import logging
 
+logging.basicConfig(level=logging.INFO)
 
 async def main():
     if len(sys.argv) < 2:

--- a/start_stub.py
+++ b/start_stub.py
@@ -1,0 +1,24 @@
+import asyncio
+import logging
+from opencj_listener import OpenCJListener
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class Stub():
+    """
+Fake Discord module that just logs received events to console
+    """
+    async def on_game_event(self, event):
+        logger.info(f'Received event: {type(event).__name__}')
+
+async def main():
+    dc = Stub()
+    ls = OpenCJListener(dc, 'stub')
+
+    logger.info('Starting stub listener')
+
+    await ls.start()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_listener.py
+++ b/test_listener.py
@@ -21,12 +21,11 @@ class OpenCJDiscord:
 async def test(dc):
     # Set up the client socket
     print('Setting up client socket...')
-    socket_path = '/tmp/opencj_events_cod4'
-    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     client.setblocking(False)
     try:
         loop = asyncio.get_event_loop()
-        await loop.sock_connect(client, socket_path)
+        await loop.sock_connect(client, ('127.0.0.1', 28961))
     except FileNotFoundError as fnfe:
         raise Exception('Could not connect to game server listener')
 

--- a/test_listener.py
+++ b/test_listener.py
@@ -62,7 +62,7 @@ async def main():
     task_listener.cancel()
 
     # Verify the data is as expected
-    expected_msg = '[Discord] test: this is an injected message'
+    expected_msg = '^8[^7Discord^8]^7 test: this is an injected message'
     if data != expected_msg:
         raise Exception(f'Expected:\n{expected_msg}\nGot\n{data}')
     else:


### PR DESCRIPTION
This PR along with other PRs in `cod4x-server` and `server-ext` repos brings in support for building OpenCJ server on Windows using mingw 11.2.0 toolchain (gcc/g++ version 11.2).

- updated Discord listener to be TCP localhost instead of unix domain socket so that it would work on both Linux and Windows
- also added stub listener that can be started instead of an actual bot